### PR TITLE
pass getState to actionTakers

### DIFF
--- a/src/actionHandler.js
+++ b/src/actionHandler.js
@@ -1,7 +1,7 @@
 // @flow
 
 import type { HorizonInstance } from '../types/horizon'
-import type { Action, Dispatch } from '../types/redux'
+import type { Action, Dispatch, GetState } from '../types/redux'
 import type {
   ActionTaker,
   ActionTakers
@@ -32,12 +32,13 @@ export function actionTakerMatchesAction (
 export function createActionHandler (
   hz: HorizonInstance,
   actionTakers: ActionTakers,
-  dispatch: Dispatch
+  dispatch: Dispatch,
+  getState: GetState
 ) {
   return (action: Action): void => {
     actionTakers.forEach((actionTaker) => {
       if (actionTakerMatchesAction(action, actionTaker)) {
-        const observable = actionTaker.observableQuery(hz, action)
+        const observable = actionTaker.observableQuery(hz, action, getState)
 
         // if this actionTaker's query has a success or error handler, set up
         // the new subscription

--- a/src/createMiddleware.js
+++ b/src/createMiddleware.js
@@ -16,7 +16,7 @@ export default function createMiddlewareCreator (
 ) {
   return (): Middleware => ({ dispatch, getState }) => {
     // create the actionHandler
-    const handleAction = createActionHandler(hz, actionTakers, dispatch)
+    const handleAction = createActionHandler(hz, actionTakers, dispatch, getState)
 
     return (next: Dispatch) => (action: Action) => {
       handleAction(action)

--- a/types/horizon-redux.js.flow
+++ b/types/horizon-redux.js.flow
@@ -1,10 +1,10 @@
 // @flow
 
-import type { Action, ActionType, Dispatch } from './redux'
+import type { Action, ActionType, Dispatch, GetState } from './redux'
 import type { HorizonInstance, HorizonObservable } from './horizon'
 
 export type ActionTakerPattern = ActionType|Array<ActionType>|(a:Action)=>boolean
-export type ActionTakerObservableQuery = (hz:HorizonInstance, action:Action)=>HorizonObservable
+export type ActionTakerObservableQuery = (hz:HorizonInstance, action:Action, getState:GetState)=>HorizonObservable
 export type ActionTakerSuccessHandler = (result:any, action:Action, dispatch:Dispatch)=>void
 export type ActionTakerErrorHandler = (err:any, action:Action, dispatch:Dispatch)=>void
 export type ActionTakerType = string

--- a/types/redux.js.flow
+++ b/types/redux.js.flow
@@ -14,6 +14,7 @@ export type Action = {
 }
 export type Reducer<State, Action> = (state: State, action: Action) => State
 export type Dispatch = (a: Action) => any
+export type GetState = () => any
 export type Store = {
   dispatch: Dispatch,
   getState: () => State,


### PR DESCRIPTION
This change adds the getState function as a third parameter to actionTaker functions, providing actionTakers with a way to reference the current state before executing any horizon actions.

here's a simple use case:

```
horizonRedux.takeLatest(
  REMOVE_CURRENT_USER,
  (horizon, action, getState) => {
    const currentUserId = getState().currentUserId;
    return horizon('activeUsers').remove({id: currentUserId});
  },
  // success handler
  // failure handler
);
```